### PR TITLE
fix the name of the tool "Arm Development Studio"

### DIFF
--- a/ads2svd.xslt
+++ b/ads2svd.xslt
@@ -433,7 +433,7 @@
           <vendor>ARM Ltd.</vendor>
           <vendorID>ARM</vendorID>
           <name><xsl:value-of select="c:core_definition/c:name"/></name>
-          <description><xsl:value-of select="c:core_definition/c:name"/> core descriptions, generated from ARM develloper studio</description>
+          <description><xsl:value-of select="c:core_definition/c:name"/> core descriptions, generated from Arm Development Studio</description>
           <cpu>
             <name><xsl:value-of select="internal:map_cpu_name(c:core_definition/c:name)"/></name>
             <series><xsl:value-of select="c:core_definition/c:series"/></series>


### PR DESCRIPTION
this is misleading as Arm have another legacy tool called Arm Developer Suite, the correct tool is "Arm Development Studio"
refer to https://developer.arm.com/tools-and-software/embedded/arm-development-studio